### PR TITLE
Fix package json main

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --target lib --name AnimatedNumber ./src/AnimatedNumber",
+    "build": "vue-cli-service build --target lib --name AnimatedNumber ./src/AnimatedNumber.vue",
     "test": "vue-cli-service test",
     "lint": "vue-cli-service lint",
     "prepublish": "npm run test && npm run build"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "animated-number"
   ],
   "description": "A vue component with number animation",
-  "main": "./src/AnimatedNumber.vue",
+  "main": "dist/AnimatedNumber.umd.min.js",
   "repository": "https://github.com/Leocardoso94/animated-number-vue.git",
   "author": "Leonardo Cardoso <leocardosoTI@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This PR fixes the path to the main entry point.
It should forward to the transpiled `dist/AnimatedNumber.umd.min.js` instead of `src`. I encountered this problem when I got errors during parsing this library with IE which is not supporting arrow syntax.

Furthermore I also added the `.vue` extension in the build script, since otherwise it was not found.